### PR TITLE
add Randall爱数学 and modify a brief introduction

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@
 | [ZJU-EE](https://github.com/alwaysbyx/ZJU-EE) | 浙江大学电气工程学院（自动化）课程指南 | GitHub |
 | [ZJU_Course](https://github.com/RyanFcr/ZJU_Course?tab=readme-ov-file) | 个人计算机课程资料整理（浙大 CS 专业） | GitHub |
 | [一起学习德智体](https://mp.weixin.qq.com/s/AebEozF9Xemqb1BfIFLayg)| 电气工程专业个人资源站 | 公众号 |
-| [路老师的 nonsense collection](https://mp.weixin.qq.com/s/-hBAeed1AWT35l6Xc5svXQ)| 微积分、线代、概统相关资源 | 公众号 |
+| [路老师的 nonsense collection](https://mp.weixin.qq.com/s/-hBAeed1AWT35l6Xc5svXQ)| 微积分相关资源 | 公众号 |
 | [Randall 爱数学](https://mp.weixin.qq.com/s/M6ulC2ljYVDZ2mqXJRST-Q) | 线代答案、回忆卷相关资源 | 公众号 |
 
 ### 笔记/教程类


### PR DESCRIPTION
- Added a new official account `Randall 爱数学`, which provides linear algebra answers and examination paper.

- Update the introduction to `路老师的 nonsense collection`. I think this official account only provides calculus resources. 

### Resource list updates (by Copilot):

- Updated the description for `路老师的 nonsense collection` to clarify that it only covers calculus resources, removing references to linear algebra and probability/statistics.
- Added a new entry for `Randall 爱数学`, which provides linear algebra answers and related materials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized resource collection for improved structure and clarity
  * Refined existing resource description to specific focus area
  * Added new resource entry to expand available content

<!-- end of auto-generated comment: release notes by coderabbit.ai -->