### PR TITLE
fix: 更新机械学院资源整理站 Hikari of ME 的链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@
 | [EEStUdy-Place](http://www.eestudy-place.com/) | 电气工程学院学习网站 | [GitHub](https://github.com/ZJU-EESUAD/EEStUdy-Place) ![GitHub stars](https://img.shields.io/github/stars/ZJU-EESUAD/EEStUdy-Place?style=social) |
 | [数学之韵](https://zju_math.pages.zjusct.io/mathweb/) | 数学专业课程经验与学习资料共享 | [ZJU Git](https://git.zju.edu.cn/zju_math/mathweb) |
 | [力速双 A - ZJUSAA](https://fsaa.pages.zjusct.io/fsaa/) | 航空航天学院学习分享平台 | [ZJU Git](https://git.zju.edu.cn/fsaa/fsaa) |
-| [Hikari of ME](https://pages.koala-studio.org.cn/hikari-of-me-6645ba/) | 机械学院资源整理站 | [ZJU Git](https://git.zju.edu.cn/hikari-of-me/hikari-of-me) |
+| [Hikari of ME](https://hikari-of-me.pages.zjusct.io/hikari-of-me/) | 机械学院资源整理站 | [ZJU Git](https://git.zju.edu.cn/hikari-of-me/hikari-of-me) |
 | [控制学习驿站](https://ctrl-a.pages.zjusct.io/CseHub/) | 控制学院学习资源整理站 | [ZJU Git](https://git.zju.edu.cn/ctrl-a/CseHub) |
 
 | 名称 | 简介 | 来源 |


### PR DESCRIPTION
更新机械学院资源整理站 Hikari of ME 的链接（由 ZJU Git 渲染的 Gitlab Pages），原先的链接已停止更新，并将在不久后弃用

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Hikari of ME entry with new hyperlink and Git source reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->